### PR TITLE
support drive number greater than 9.

### DIFF
--- a/Zbx-HPSmartArray.ps1
+++ b/Zbx-HPSmartArray.ps1
@@ -114,7 +114,7 @@ function Make-LLD() {
                     $all_pd = & "$ssacli" "ctrl slot=$($ctrl_slot) pd all show status".Split() | Where-Object {$_ -match "physicaldrive"}
                     
                     foreach ($pd in $all_pd) {
-                        if ($pd -match "physicaldrive (?<Num>\d{1,}\w(:?\d){1,2}) \(.+ (?<Capacity>\d{1,} [KGT]B?)\)") {
+                        if ($pd -match "physicaldrive (?<Num>\d{1,}\w(:?\d){1,3}) \(.+ (?<Capacity>\d{1,} [KGT]B?)\)") {
                             [array]$lld_obj_list += [psobject]@{"{#PD.NUM}" = $Matches.Num;
                                                                 "{#PD.CAPACITY}" = $Matches.Capacity;
                                                                 "{#CTRL.SLOT}" = $ctrl_slot;


### PR DESCRIPTION
Hi, lld did not show drive numbers greater than 9. I fixed the regex hopefully. Now drive numbers with two digits are also supportet. Best regards, Ulf